### PR TITLE
fix: change to instances supported by `image-classification`

### DIFF
--- a/prod-config.json
+++ b/prod-config.json
@@ -2,7 +2,7 @@
   "Parameters": {
     "StageName": "prod",
     "EndpointInstanceCount": "1",
-    "EndpointInstanceType": "ml.m5.large",
+    "EndpointInstanceType": "ml.m4.xlarge",
     "SamplingPercentage": "80",
     "EnableDataCapture": "true"
   }

--- a/staging-config.json
+++ b/staging-config.json
@@ -2,7 +2,7 @@
   "Parameters": {
     "StageName": "staging",
     "EndpointInstanceCount": "1",
-    "EndpointInstanceType": "ml.m5.large",
+    "EndpointInstanceType": "ml.m4.xlarge",
     "SamplingPercentage": "100",
     "EnableDataCapture": "true"
   }


### PR DESCRIPTION
## What
As a hotfix, use `ml.m4.xlarge` instance as suggested in this tutorial https://sagemaker-examples.readthedocs.io/en/latest/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-fulltraining.html#HostTheModel to deploy `image-classification` model for Amazon SageMaker Realtime Inference endpoint.

I could not find any more documentation/info on supported instances for the used Amazon SageMaker model inference.

## Why
[EndpointConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-endpointconfig.html) creation for the endpoint fails with
> The requested real-time inference instance type ml.m5.large is not supported by one or more ModelPackages used to create the Model.

This makes the CloudFormation stack fail to deploy.

## Testing
None this time